### PR TITLE
Fix Team Ops main menu icon when not the last item

### DIFF
--- a/Software/Application/Indexer/dev_indexer.js
+++ b/Software/Application/Indexer/dev_indexer.js
@@ -303,8 +303,8 @@ var errorSubmissions = [];
                 <li class="gd-team-ops-cp main_menu_item  last " data-option-id="teamops">
                     <span class="content_wrapper">
                         <span class="button_wrapper">
-                            <div class="btn_settings circle_button" style="right: 0px; top: 0 !important;">
-                                <div style="margin: 7px 0px 0px 4px; width: 24px; height: 24px;">${gd_icon_svg}</div>
+                            <div class="button">
+                                <div style="left: 20px; margin-top: 6px;">${gd_icon_svg}</div>
                             </div>
                             <span class="indicator gd-teamops-indicator" data-indicator-id="teamops" style="display: none;"></span>
                         </span>

--- a/Software/Application/Indexer/indexer.js
+++ b/Software/Application/Indexer/indexer.js
@@ -303,8 +303,8 @@ var errorSubmissions = [];
                 <li class="gd-team-ops-cp main_menu_item  last " data-option-id="teamops">
                     <span class="content_wrapper">
                         <span class="button_wrapper">
-                            <div class="btn_settings circle_button" style="right: 0px; top: 0 !important;">
-                                <div style="margin: 7px 0px 0px 4px; width: 24px; height: 24px;">${gd_icon_svg}</div>
+                            <div class="button">
+                                <div style="left: 20px; margin-top: 6px;">${gd_icon_svg}</div>
                             </div>
                             <span class="indicator gd-teamops-indicator" data-indicator-id="teamops" style="display: none;"></span>
                         </span>


### PR DESCRIPTION
When another script adds a menu item under the Team Ops option and removes the `last` class from it the icon will become mispositioned.
I went ahed and bumped the patch version too (i hope i didn't overstep).

Before the fix:
<p>
  <img src="https://github.com/user-attachments/assets/029a70e3-5645-47cd-8720-83b7bb71ddfb" />
</p>

After the fix:
<p>
  <img src="https://github.com/user-attachments/assets/11681680-51a9-48a9-aef8-4f3172f1c091" />
  <img src="https://github.com/user-attachments/assets/fe1dc41c-66c6-4f7a-9c1e-8b38d3379f67" />
</p>